### PR TITLE
Text Sticker don't always show full text, now they do

### DIFF
--- a/Sources/Extensions/UIView+ZLImageEditor.swift
+++ b/Sources/Extensions/UIView+ZLImageEditor.swift
@@ -1,0 +1,22 @@
+//
+//  UIView+ZLImageEditor.swift
+//  ZLImageEditor
+//
+//  Created by Bartosz on 11/05/2022.
+//
+
+import UIKit
+
+extension UIView {
+    func fillInSuperview() {
+        guard let superview = superview else {
+            return
+        }
+
+        translatesAutoresizingMaskIntoConstraints = false
+        leftAnchor.constraint(equalTo: superview.leftAnchor).isActive = true
+        topAnchor.constraint(equalTo: superview.topAnchor).isActive = true
+        rightAnchor.constraint(equalTo: superview.rightAnchor).isActive = true
+        bottomAnchor.constraint(equalTo: superview.bottomAnchor).isActive = true
+    }
+}

--- a/Sources/General/ZLTextStickerView.swift
+++ b/Sources/General/ZLTextStickerView.swift
@@ -145,7 +145,8 @@ class ZLTextStickerView: UIView, ZLStickerViewAdditional {
         self.label.numberOfLines = 0
         self.label.lineBreakMode = .byCharWrapping
         self.borderView.addSubview(self.label)
-        
+        self.label.fillInSuperview()
+
         self.tapGes = UITapGestureRecognizer(target: self, action: #selector(tapAction(_:)))
         self.addGestureRecognizer(self.tapGes)
         
@@ -463,5 +464,4 @@ public class ZLTextStickerState: NSObject {
         self.textFont = font
         super.init()
     }
-    
 }

--- a/ZLImageEditor.xcodeproj/project.pbxproj
+++ b/ZLImageEditor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		985A2DA9282B92F2007AE0C6 /* UIView+ZLImageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985A2DA8282B92F2007AE0C6 /* UIView+ZLImageEditor.swift */; };
 		E40208DC256B9BA60077F5DC /* ZLImageEditor.h in Headers */ = {isa = PBXBuildFile; fileRef = E40208DA256B9BA60077F5DC /* ZLImageEditor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E40208EB256B9F9C0077F5DC /* ZLEditImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40208E4256B9F9C0077F5DC /* ZLEditImageViewController.swift */; };
 		E40208EC256B9F9C0077F5DC /* ZLImageStickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40208E5256B9F9C0077F5DC /* ZLImageStickerView.swift */; };
@@ -32,6 +33,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		985A2DA8282B92F2007AE0C6 /* UIView+ZLImageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ZLImageEditor.swift"; sourceTree = "<group>"; };
 		E40208D7256B9BA60077F5DC /* ZLImageEditor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZLImageEditor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E40208DA256B9BA60077F5DC /* ZLImageEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZLImageEditor.h; sourceTree = "<group>"; };
 		E40208DB256B9BA60077F5DC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				E40208FC256BA0080077F5DC /* Cell+ZLImageEditor.swift */,
 				E40208FA256BA0080077F5DC /* String+ZLImageEditor.swift */,
 				E40208F9256BA0070077F5DC /* UIImage+ZLImageEditor.swift */,
+				985A2DA8282B92F2007AE0C6 /* UIView+ZLImageEditor.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -214,6 +217,7 @@
 				E4020912256BA27D0077F5DC /* ZLImageEditorConfiguration.swift in Sources */,
 				E40208F4256B9FA70077F5DC /* ZLClipImageDismissAnimatedTransition.swift in Sources */,
 				E40208FE256BA0080077F5DC /* String+ZLImageEditor.swift in Sources */,
+				985A2DA9282B92F2007AE0C6 /* UIView+ZLImageEditor.swift in Sources */,
 				E40208FD256BA0080077F5DC /* UIImage+ZLImageEditor.swift in Sources */,
 				FD8EFA54277206D30067ADF1 /* ZLEditToolCells.swift in Sources */,
 				E40208FF256BA0080077F5DC /* Bundle+ZLImageEditor.swift in Sources */,


### PR DESCRIPTION
I had the problem that when writing too much text into a text sticker, it wouldn't always show all the text, mostly it cut of the last word or a bit more. Setting constraints to those from the borderView seems to fix that bug.