### PR TITLE
fix japanese localization.

### DIFF
--- a/Sources/ZLImageEditor.bundle/ja-US.lproj/Localizable.strings
+++ b/Sources/ZLImageEditor.bundle/ja-US.lproj/Localizable.strings
@@ -1,9 +1,9 @@
 "cancel" = "キャンセル";
 "done" = "確定";
-"editFinish" = "編集完了";
+"editFinish" = "完了";
 "revert" = "元に戻す";
-"brightness" = "明度";
+"brightness" = "明るさ";
 "contrast" = "コントラスト";
-"saturation" = "彩度";
+"saturation" = "暖かさ";
 "textStickerRemoveTips" = "ここにドラッグして削除します";
 "hudLoading" = "お待ち下さい";


### PR DESCRIPTION
Hi, @longitachi.

I changed japanese localization.
I think these japanese words are more familiar to japanese people than previous words.

- "完了" is used in iOS standard keyboard.
- "明るさ" and "暖かさ" are used in Instagram app.

I'd appreciate it if you could merge this change.
Thank you!