### PR TITLE
Fix layout re-update when orientation is changed.

### DIFF
--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -476,6 +476,11 @@ open class ZLEditImageViewController: UIViewController {
             drawColorCollectionView?.scrollToItem(at: IndexPath(row: index, section: 0), at: .centeredHorizontally, animated: false)
         }
     }
+
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        shouldLayout = true
+    }
     
     func generateFilterImages() {
         let size: CGSize


### PR DESCRIPTION
Hi @longitachi,

I fixed layout bug when device orientation is changed.

I'd appreciate it if you could merge this change.
Thank you!

Before | After
--- | ---
<img src="https://user-images.githubusercontent.com/19259885/188523695-b6c5c1ff-2a66-4fdb-b4e7-f7103ca61eb1.gif" width="380"> | <img src="https://user-images.githubusercontent.com/19259885/188523710-ef0b097b-81ac-44ae-a22a-a59f91adcb91.gif" width="380">

