### PR TITLE
Add toolIconHighlightedColor

### DIFF
--- a/Sources/Extensions/UIColor+ZLImageEditor.swift
+++ b/Sources/Extensions/UIColor+ZLImageEditor.swift
@@ -58,4 +58,8 @@ extension ZLImageEditorWrapper where Base: UIColor {
     static var toolTitleTintColor: UIColor {
         ZLImageEditorUIConfiguration.default().toolTitleTintColor
     }
+
+    static var toolIconHighlightedColor: UIColor? {
+        ZLImageEditorUIConfiguration.default().toolIconHighlightedColor
+    }
 }

--- a/Sources/Extensions/UIImage+ZLImageEditor.swift
+++ b/Sources/Extensions/UIImage+ZLImageEditor.swift
@@ -338,6 +338,18 @@ extension ZLImageEditorWrapper where Base: UIImage {
         }
         return UIImage(data: data) ?? base
     }
+
+    func fillColor(_ color: UIColor) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(base.size, false, base.scale)
+        let drawRect = CGRect(x: 0,y: 0,width: base.size.width,height: base.size.height)
+        color.setFill()
+        UIRectFill(drawRect)
+        base.draw(in: drawRect, blendMode: .destinationIn, alpha: 1)
+
+        let tintedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return tintedImage!
+    }
 }
 
 extension ZLImageEditorWrapper where Base: UIImage {

--- a/Sources/Extensions/UIImage+ZLImageEditor.swift
+++ b/Sources/Extensions/UIImage+ZLImageEditor.swift
@@ -341,14 +341,14 @@ extension ZLImageEditorWrapper where Base: UIImage {
 
     func fillColor(_ color: UIColor) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(base.size, false, base.scale)
-        let drawRect = CGRect(x: 0,y: 0,width: base.size.width,height: base.size.height)
+        let drawRect = CGRect(x: 0, y: 0, width: base.size.width, height: base.size.height)
         color.setFill()
         UIRectFill(drawRect)
         base.draw(in: drawRect, blendMode: .destinationIn, alpha: 1)
 
         let tintedImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return tintedImage!
+        return tintedImage
     }
 }
 

--- a/Sources/General/ZLEditToolCells.swift
+++ b/Sources/General/ZLEditToolCells.swift
@@ -52,6 +52,10 @@ class ZLEditToolCell: UICollectionViewCell {
                 icon.image = getImage("zl_adjust")
                 icon.highlightedImage = getImage("zl_adjust_selected")
             }
+            if let color = UIColor.zl.toolIconHighlightedColor {
+                icon.highlightedImage = icon.highlightedImage?
+                    .zl.fillColor(color)
+            }
         }
     }
     
@@ -163,6 +167,10 @@ class ZLAdjustToolCell: UICollectionViewCell {
                 imageView.image = getImage("zl_saturation")
                 imageView.highlightedImage = getImage("zl_saturation_selected")
                 nameLabel.text = localLanguageTextValue(.saturation)
+            }
+            if let color = UIColor.zl.toolIconHighlightedColor {
+                imageView.highlightedImage = imageView.highlightedImage?
+                    .zl.fillColor(color)
             }
         }
     }

--- a/Sources/General/ZLImageEditorUIConfiguration+Chaining.swift
+++ b/Sources/General/ZLImageEditorUIConfiguration+Chaining.swift
@@ -104,4 +104,10 @@ public extension ZLImageEditorUIConfiguration {
         toolTitleTintColor = color
         return self
     }
+
+    @discardableResult
+    func toolIconHighlightedColor(_ color: UIColor) -> ZLImageEditorUIConfiguration {
+        toolIconHighlightedColor = color
+        return self
+    }
 }

--- a/Sources/General/ZLImageEditorUIConfiguration.swift
+++ b/Sources/General/ZLImageEditorUIConfiguration.swift
@@ -123,6 +123,9 @@ public class ZLImageEditorUIConfiguration: NSObject {
     
     /// The tint color of the title below the various tools in the image editor.
     @objc public var toolTitleTintColor = UIColor.white
+
+    /// The highlighted color of the tool icon.
+    @objc public var toolIconHighlightedColor: UIColor?
 }
 
 // MARK: Image source deploy


### PR DESCRIPTION
Hi @longitachi,

I added new UI color configuration `toolIconHighlightedColor`.

Currently, we can change the colors of Done button background and tool title and so on.
However we can't change the color of tool icon.
So, this suggestion is resolved this problem by new configuration setting.

```swift
let myPrimaryColor = UIColor.orange
ZLImageEditorUIConfiguration.default()
    .adjustSliderTintColor(myPrimaryColor)
    .editDoneBtnBgColor(myPrimaryColor)
    .ashbinTintBgColor(myPrimaryColor)
    .toolTitleTintColor(myPrimaryColor)
    .toolIconHighlightedColor(myPrimaryColor) // new
```

Before | After
--- | ---
<img src="https://user-images.githubusercontent.com/19259885/192202694-eb243cae-b0d0-478a-8716-e8bd9c0a2d0c.png"> | <img src="https://user-images.githubusercontent.com/19259885/192202767-7a31e03d-ce8e-432d-88dc-5a8adc7a464d.png">

