### PR TITLE
Support text sticker line break

### DIFF
--- a/Sources/General/ZLImageEditorConfiguration+Chaining.swift
+++ b/Sources/General/ZLImageEditorConfiguration+Chaining.swift
@@ -62,6 +62,12 @@ public extension ZLImageEditorConfiguration {
         textStickerDefaultTextColor = color
         return self
     }
+
+    @discardableResult
+    func textStickerCanLineBreak(_ enable: Bool) -> ZLImageEditorConfiguration {
+        textStickerCanLineBreak = enable
+        return self
+    }
     
     @discardableResult
     func filters(_ filters: [ZLFilter]) -> ZLImageEditorConfiguration {

--- a/Sources/General/ZLImageEditorConfiguration.swift
+++ b/Sources/General/ZLImageEditorConfiguration.swift
@@ -104,6 +104,9 @@ public class ZLImageEditorConfiguration: NSObject {
     
     /// The default text sticker color. If this color not in textStickerTextColors, will pick the first color in textStickerTextColors as the default.
     @objc public var textStickerDefaultTextColor = UIColor.white
+
+    /// Whether text sticker allows line break.
+    @objc public var textStickerCanLineBreak = false
     
     private var pri_filters: [ZLFilter] = ZLFilter.all
     /// Filters for image editor.

--- a/Sources/General/ZLInputTextViewController.swift
+++ b/Sources/General/ZLInputTextViewController.swift
@@ -170,6 +170,7 @@ class ZLInputTextViewController: UIViewController {
     }
     
     @objc func doneBtnClick() {
+        textView.text = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
         endInput?(textView.text, textView.font ?? UIFont.systemFont(ofSize: ZLTextStickerView.fontSize), currentTextColor, .clear)
         dismiss(animated: true, completion: nil)
     }

--- a/Sources/General/ZLInputTextViewController.swift
+++ b/Sources/General/ZLInputTextViewController.swift
@@ -139,7 +139,8 @@ class ZLInputTextViewController: UIViewController {
         
         textView = UITextView(frame: .zero)
         textView.keyboardAppearance = .dark
-        textView.returnKeyType = .done
+        textView.returnKeyType = ZLImageEditorConfiguration.default().textStickerCanLineBreak ? .default : .done
+        textView.indicatorStyle = .white
         textView.delegate = self
         textView.backgroundColor = .clear
         textView.tintColor = .zl.editDoneBtnBgColor
@@ -213,7 +214,7 @@ extension ZLInputTextViewController: UICollectionViewDelegate, UICollectionViewD
 
 extension ZLInputTextViewController: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        if text == "\n" {
+        if !ZLImageEditorConfiguration.default().textStickerCanLineBreak && text == "\n" {
             doneBtnClick()
             return false
         }


### PR DESCRIPTION
Hi @longitachi,

My app's customer requests input line break on text sticker.
So I added new configuration `textStickerCanLineBreak`.

I'm appreciate if you would review this proposal.

Thank you.

<img width="380" src="https://user-images.githubusercontent.com/19259885/197328782-07d90a63-32b1-4431-9d2f-072c2e6e1431.png"/>

