### PR TITLE
Add horizontal adjust slider

### DIFF
--- a/Sources/General/ZLAdjustHSlider.swift
+++ b/Sources/General/ZLAdjustHSlider.swift
@@ -1,0 +1,127 @@
+//
+//  ZLAdjustHSlider.swift
+//  ZLImageEditor
+//
+//  Created by darquro on 2022/12/05.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+
+protocol ZLAdjustHSliderable: UIView {
+    var value: Float { get set }
+}
+
+/// Horizontal Adjust Slider
+@available(iOS 14.0, *)
+final class ZLAdjustHSlider: UIView {
+
+    // MARK: View Components
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(frame: frame)
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        return stackView
+    }()
+
+    private lazy var slider: UISlider = {
+        let slider = UISlider()
+        slider.minimumValue = -1
+        slider.maximumValue = 1
+        slider.value = 0
+        slider.tintColor = ZLImageEditorUIConfiguration.default().adjustSliderTintColor
+        slider.addAction(.init{ [weak self] action in
+            guard let slider = action.sender as? UISlider else { return }
+            if slider.value == 0,
+               ZLImageEditorConfiguration.default().impactFeedbackWhenAdjustSliderValueIsZero {
+                let style = ZLImageEditorConfiguration.default().impactFeedbackStyle.uiFeedback
+                UIImpactFeedbackGenerator(style: style).impactOccurred()
+            }
+            self?.label.text = "\(Int(slider.value * 100))"
+            self?.valueChanged?(slider.value)
+        }, for: .valueChanged)
+        return slider
+    }()
+
+    private lazy var label: UILabel = {
+        let label = UILabel(frame: .init(x: 0, y: 0, width: 50, height: 30))
+        label.textColor = .white
+        label.textAlignment = .center
+        label.text = "0"
+        return label
+    }()
+
+    // MARK: Properties
+
+    var valueChanged: ((Float) -> Void)? = nil
+
+    // MARK: Initializer
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isHidden = true
+
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leftAnchor.constraint(equalTo: leftAnchor),
+            stackView.rightAnchor.constraint(equalTo: rightAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        stackView.addArrangedSubview(label)
+        NSLayoutConstraint.activate([
+            label.leftAnchor.constraint(equalTo: stackView.leftAnchor),
+            label.rightAnchor.constraint(equalTo: stackView.rightAnchor),
+        ])
+
+        stackView.addArrangedSubview(slider)
+        NSLayoutConstraint.activate([
+            slider.leftAnchor.constraint(equalTo: stackView.leftAnchor),
+            slider.rightAnchor.constraint(equalTo: stackView.rightAnchor),
+        ])
+    }
+
+    // MARK: View Lifecycle
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        stackView.frame = .init(x: 0, y: 0, width: frame.width, height: frame.height)
+    }
+}
+
+@available(iOS 14.0, *)
+extension ZLAdjustHSlider: ZLAdjustHSliderable {
+
+    var value: Float {
+        get {
+            slider.value
+        }
+        set {
+            slider.setValue(newValue, animated: false)
+            label.text = "\(Int(newValue * 100))"
+        }
+    }
+}

--- a/Sources/General/ZLAdjustHSlider.swift
+++ b/Sources/General/ZLAdjustHSlider.swift
@@ -33,18 +33,40 @@ final class ZLAdjustHSlider: UIView, ZLAdjustSliderable {
         let stackView = UIStackView(frame: frame)
         stackView.axis = .vertical
         stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
 
-    private lazy var slider: UISlider = {
-        let slider = UISlider()
-        slider.minimumValue = -1
-        slider.maximumValue = 1
-        slider.value = 0
-        slider.tintColor = ZLImageEditorUIConfiguration.default().adjustSliderTintColor
-        slider.addTarget(self, action: #selector(onValueChanged(_:)), for: .valueChanged)
-        slider.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onSliderTapped(_:))))
-        return slider
+    private lazy var trackViewContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onSliderTapped(_:))))
+        return view
+    }()
+
+    private lazy var backgroundTrackView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .darkGray
+        view.layer.cornerRadius = 4
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private lazy var valueTrackView: UIView = {
+        let view = UIView()
+        view.backgroundColor = ZLImageEditorUIConfiguration.default().adjustSliderTintColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let thumbWidth = 30.0
+    private lazy var thumbView: UIView = {
+        let view = UIView(frame: .init(x: 0, y: 0, width: thumbWidth, height: thumbWidth))
+        view.backgroundColor = .white
+        view.layer.cornerRadius = thumbWidth / 2
+        view.isUserInteractionEnabled = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
 
     private lazy var label: UILabel = {
@@ -56,17 +78,28 @@ final class ZLAdjustHSlider: UIView, ZLAdjustSliderable {
         return label
     }()
 
+    // MARK: Constraints
+
+    private var valueTrackLeftConstraint: NSLayoutConstraint?
+    private var valueTrackRightConstraint: NSLayoutConstraint?
+
+    // MARK: Private Properties
+
+    private let range: ClosedRange<Float> = -1...1
+
+    private var actualValue: Float = 0
+
     // MARK: ZLAdjustSliderable
 
     let type: ZLAdjustSliderType = .horizontal
 
     var value: Float {
-        get {
-            slider.value
-        }
+        get { actualValue }
         set {
-            slider.setValue(newValue, animated: false)
-            updateLabel()
+            actualValue = newValue
+            updateLabel(newValue)
+            updateThumb(newValue)
+            updateValueTrackConstraint(newValue)
         }
     }
 
@@ -83,22 +116,12 @@ final class ZLAdjustHSlider: UIView, ZLAdjustSliderable {
         super.init(frame: frame)
 
         addSubview(stackView)
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        if UIDevice.current.userInterfaceIdiom == .phone {
             NSLayoutConstraint.activate([
                 stackView.topAnchor.constraint(equalTo: topAnchor),
                 stackView.leftAnchor.constraint(equalTo: leftAnchor, constant: 40),
                 stackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -40),
                 stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
             ])
-        } else {
-            NSLayoutConstraint.activate([
-                stackView.topAnchor.constraint(equalTo: topAnchor),
-                stackView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5),
-                stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
-                stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            ])
-        }
 
         stackView.addArrangedSubview(label)
         NSLayoutConstraint.activate([
@@ -106,39 +129,153 @@ final class ZLAdjustHSlider: UIView, ZLAdjustSliderable {
             label.rightAnchor.constraint(equalTo: stackView.rightAnchor),
         ])
 
-        stackView.addArrangedSubview(slider)
+        stackView.addArrangedSubview(trackViewContainer)
         NSLayoutConstraint.activate([
-            slider.leftAnchor.constraint(equalTo: stackView.leftAnchor),
-            slider.rightAnchor.constraint(equalTo: stackView.rightAnchor),
+            trackViewContainer.leftAnchor.constraint(equalTo: stackView.leftAnchor),
+            trackViewContainer.rightAnchor.constraint(equalTo: stackView.rightAnchor),
+            trackViewContainer.heightAnchor.constraint(equalToConstant: thumbWidth),
+        ])
+
+        trackViewContainer.addSubview(backgroundTrackView)
+        NSLayoutConstraint.activate([
+            backgroundTrackView.centerYAnchor.constraint(equalTo: trackViewContainer.centerYAnchor),
+            backgroundTrackView.centerXAnchor.constraint(equalTo: trackViewContainer.centerXAnchor),
+            backgroundTrackView.widthAnchor.constraint(equalTo: trackViewContainer.widthAnchor, constant: -thumbWidth),
+            backgroundTrackView.heightAnchor.constraint(equalToConstant: 4),
+        ])
+
+        backgroundTrackView.addSubview(valueTrackView)
+        valueTrackLeftConstraint = valueTrackView.leftAnchor.constraint(equalTo: backgroundTrackView.leftAnchor)
+        valueTrackRightConstraint = valueTrackView.rightAnchor.constraint(equalTo: backgroundTrackView.rightAnchor)
+        NSLayoutConstraint.activate([
+            valueTrackView.topAnchor.constraint(equalTo: backgroundTrackView.topAnchor),
+            valueTrackLeftConstraint!,
+            valueTrackRightConstraint!,
+            valueTrackView.bottomAnchor.constraint(equalTo: backgroundTrackView.bottomAnchor),
+        ])
+
+        trackViewContainer.addSubview(thumbView)
+        NSLayoutConstraint.activate([
+            thumbView.widthAnchor.constraint(equalToConstant: thumbView.frame.width),
+            thumbView.heightAnchor.constraint(equalToConstant: thumbView.frame.height),
+            thumbView.centerXAnchor.constraint(equalTo: trackViewContainer.centerXAnchor),
+            thumbView.centerYAnchor.constraint(equalTo: trackViewContainer.centerYAnchor),
         ])
     }
 }
 
+// MARK: - Override
 extension ZLAdjustHSlider {
 
-    @objc func onValueChanged(_ sender: UISlider) {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        valueTrackLeftConstraint?.constant = frame.width / 2
+        valueTrackRightConstraint?.constant = -frame.width / 2
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first, touch.view == thumbView else { return }
+
+        // define next location, minX, maxX
+        let nextLocation = touch.location(in: trackViewContainer)
+        let thumbHalf = thumbWidth / 2
+        let nextLocationX = nextLocation.x - thumbHalf
+        let minX = backgroundTrackView.frame.origin.x - thumbHalf
+        let maxX = backgroundTrackView.frame.origin.x + backgroundTrackView.frame.width - thumbHalf
+        let limitedLocationX: CGFloat = {
+            if nextLocationX < minX {
+                return minX
+            } else if nextLocationX > maxX {
+                return maxX
+            }
+            return nextLocationX
+        }()
+
+        // set next location
+        thumbView.frame.origin = .init(x: limitedLocationX, y: thumbView.frame.origin.y)
+
+        // calc slider value
+        let halfTrack = backgroundTrackView.frame.width / 2
+        let diff = thumbView.center.x - backgroundTrackView.frame.origin.x - halfTrack
+        let sliderValue = diff / halfTrack
+        let roundedValue: CGFloat = {
+            if sliderValue < 0, Float(sliderValue) < range.lowerBound {
+                return CGFloat(range.lowerBound)
+            } else if sliderValue > 0, Float(sliderValue) > range.upperBound {
+                return CGFloat(range.upperBound)
+            }
+            return sliderValue
+        }()
+
+        // update constraint
+        updateValueTrackConstraint(Float(roundedValue))
+
+        // impact feedback
         if #available(iOS 10.0, *) {
-            if sender.value == 0,
+            if roundedValue == 0,
                ZLImageEditorConfiguration.default().impactFeedbackWhenAdjustSliderValueIsZero {
                 let style = ZLImageEditorConfiguration.default().impactFeedbackStyle.uiFeedback
                 UIImpactFeedbackGenerator(style: style).impactOccurred()
             }
         }
-        updateLabel()
-        valueChanged?(sender.value)
+
+        // update value
+        let newValue = Float(roundedValue)
+        actualValue = newValue
+        updateLabel(newValue)
+        valueChanged?(newValue)
+    }
+}
+
+// MARK: - Private
+extension ZLAdjustHSlider {
+
+    @objc private func onSliderTapped(_ recognizer: UITapGestureRecognizer) {
+        let tapLocation = recognizer.location(in: backgroundTrackView)
+        let thumbHalf = thumbWidth / 2
+        let minX = backgroundTrackView.frame.origin.x - thumbHalf
+        let maxX = backgroundTrackView.frame.origin.x + backgroundTrackView.frame.width - thumbHalf
+        guard tapLocation.x >= minX,
+              tapLocation.x <= maxX else {
+            return
+        }
+        let trackHalf = backgroundTrackView.frame.size.width / 2
+        let diff = tapLocation.x - trackHalf
+        let newValue = Float(diff / trackHalf)
+        actualValue = newValue
+        updateLabel(newValue)
+        UIView.animate(withDuration: 0.1,
+                       delay: 0,
+                       options: .curveEaseOut) { [weak self] in
+            self?.updateThumb(newValue)
+            self?.updateValueTrackConstraint(newValue)
+            self?.valueChanged?(newValue)
+        }
     }
 
-    @objc func onSliderTapped(_ recognizer: UITapGestureRecognizer) {
-        let tapLocation = recognizer.location(in: slider)
-        let sliderHalfWidth = slider.frame.size.width / 2
-        let diff = tapLocation.x - sliderHalfWidth
-        let newValue = diff / sliderHalfWidth
-        slider.setValue(Float(newValue), animated: true)
-        updateLabel()
-        valueChanged?(slider.value)
+    private func updateLabel(_ value: Float) {
+        label.text = "\(Int(value * 100))"
     }
 
-    private func updateLabel() {
-        label.text = "\(Int(slider.value * 100))"
+    private func updateThumb(_ value: Float) {
+        guard value >= range.lowerBound, value <= range.upperBound else { return }
+        let trackHalf = backgroundTrackView.frame.width / 2
+        let diff = CGFloat(value) * trackHalf
+        let thumbCenterX = diff + backgroundTrackView.frame.origin.x + trackHalf
+        thumbView.center.x = thumbCenterX
+    }
+
+    private func updateValueTrackConstraint(_ value: Float) {
+        // prevent run on initialization
+        guard backgroundTrackView.frame.width > 0 else { return }
+
+        let trackHalf = backgroundTrackView.frame.width / 2
+        if value < 0 {
+            valueTrackLeftConstraint?.constant = thumbView.center.x
+            valueTrackRightConstraint?.constant = -trackHalf
+        } else {
+            valueTrackLeftConstraint?.constant = trackHalf
+            valueTrackRightConstraint?.constant = -(backgroundTrackView.frame.width - thumbView.center.x)
+        }
     }
 }

--- a/Sources/General/ZLAdjustHSlider.swift
+++ b/Sources/General/ZLAdjustHSlider.swift
@@ -24,12 +24,8 @@
 
 import UIKit
 
-protocol ZLAdjustHSliderable: UIView {
-    var value: Float { get set }
-}
-
 /// Horizontal Adjust Slider
-final class ZLAdjustHSlider: UIView {
+final class ZLAdjustHSlider: UIView, ZLAdjustSliderable {
 
     // MARK: View Components
 
@@ -60,19 +56,31 @@ final class ZLAdjustHSlider: UIView {
         return label
     }()
 
-    // MARK: Properties
+    // MARK: ZLAdjustSliderable
+
+    let type: ZLAdjustSliderType = .horizontal
+
+    var value: Float {
+        get {
+            slider.value
+        }
+        set {
+            slider.setValue(newValue, animated: false)
+            updateLabel()
+        }
+    }
 
     var valueChanged: ((Float) -> Void)? = nil
 
     // MARK: Initializer
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override init(frame: CGRect) {
+    override init(frame: CGRect = .zero) {
         super.init(frame: frame)
-        isHidden = true
 
         addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -132,18 +140,5 @@ extension ZLAdjustHSlider {
 
     private func updateLabel() {
         label.text = "\(Int(slider.value * 100))"
-    }
-}
-
-extension ZLAdjustHSlider: ZLAdjustHSliderable {
-
-    var value: Float {
-        get {
-            slider.value
-        }
-        set {
-            slider.setValue(newValue, animated: false)
-            updateLabel()
-        }
     }
 }

--- a/Sources/General/ZLAdjustHSlider.swift
+++ b/Sources/General/ZLAdjustHSlider.swift
@@ -89,8 +89,8 @@ final class ZLAdjustHSlider: UIView {
         if UIDevice.current.userInterfaceIdiom == .phone {
             NSLayoutConstraint.activate([
                 stackView.topAnchor.constraint(equalTo: topAnchor),
-                stackView.leftAnchor.constraint(equalTo: leftAnchor, constant: 20),
-                stackView.rightAnchor.constraint(equalTo: rightAnchor, constant: 20),
+                stackView.leftAnchor.constraint(equalTo: leftAnchor, constant: 40),
+                stackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -40),
                 stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
             ])
         } else {

--- a/Sources/General/ZLAdjustHSlider.swift
+++ b/Sources/General/ZLAdjustHSlider.swift
@@ -29,7 +29,6 @@ protocol ZLAdjustHSliderable: UIView {
 }
 
 /// Horizontal Adjust Slider
-@available(iOS 14.0, *)
 final class ZLAdjustHSlider: UIView {
 
     // MARK: View Components
@@ -47,16 +46,7 @@ final class ZLAdjustHSlider: UIView {
         slider.maximumValue = 1
         slider.value = 0
         slider.tintColor = ZLImageEditorUIConfiguration.default().adjustSliderTintColor
-        slider.addAction(.init{ [weak self] action in
-            guard let slider = action.sender as? UISlider else { return }
-            if slider.value == 0,
-               ZLImageEditorConfiguration.default().impactFeedbackWhenAdjustSliderValueIsZero {
-                let style = ZLImageEditorConfiguration.default().impactFeedbackStyle.uiFeedback
-                UIImpactFeedbackGenerator(style: style).impactOccurred()
-            }
-            self?.updateLabel()
-            self?.valueChanged?(slider.value)
-        }, for: .valueChanged)
+        slider.addTarget(self, action: #selector(onValueChanged(_:)), for: .valueChanged)
         slider.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onSliderTapped(_:))))
         return slider
     }()
@@ -116,8 +106,19 @@ final class ZLAdjustHSlider: UIView {
     }
 }
 
-@available(iOS 14.0, *)
 extension ZLAdjustHSlider {
+
+    @objc func onValueChanged(_ sender: UISlider) {
+        if #available(iOS 10.0, *) {
+            if sender.value == 0,
+               ZLImageEditorConfiguration.default().impactFeedbackWhenAdjustSliderValueIsZero {
+                let style = ZLImageEditorConfiguration.default().impactFeedbackStyle.uiFeedback
+                UIImpactFeedbackGenerator(style: style).impactOccurred()
+            }
+        }
+        updateLabel()
+        valueChanged?(sender.value)
+    }
 
     @objc func onSliderTapped(_ recognizer: UITapGestureRecognizer) {
         let tapLocation = recognizer.location(in: slider)
@@ -134,7 +135,6 @@ extension ZLAdjustHSlider {
     }
 }
 
-@available(iOS 14.0, *)
 extension ZLAdjustHSlider: ZLAdjustHSliderable {
 
     var value: Float {

--- a/Sources/General/ZLAdjustHSlider.swift
+++ b/Sources/General/ZLAdjustHSlider.swift
@@ -54,9 +54,10 @@ final class ZLAdjustHSlider: UIView {
                 let style = ZLImageEditorConfiguration.default().impactFeedbackStyle.uiFeedback
                 UIImpactFeedbackGenerator(style: style).impactOccurred()
             }
-            self?.label.text = "\(Int(slider.value * 100))"
+            self?.updateLabel()
             self?.valueChanged?(slider.value)
         }, for: .valueChanged)
+        slider.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onSliderTapped(_:))))
         return slider
     }()
 
@@ -64,6 +65,7 @@ final class ZLAdjustHSlider: UIView {
         let label = UILabel(frame: .init(x: 0, y: 0, width: 50, height: 30))
         label.textColor = .white
         label.textAlignment = .center
+        label.font = label.font.withSize(16)
         label.text = "0"
         return label
     }()
@@ -84,12 +86,21 @@ final class ZLAdjustHSlider: UIView {
 
         addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.leftAnchor.constraint(equalTo: leftAnchor),
-            stackView.rightAnchor.constraint(equalTo: rightAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            NSLayoutConstraint.activate([
+                stackView.topAnchor.constraint(equalTo: topAnchor),
+                stackView.leftAnchor.constraint(equalTo: leftAnchor, constant: 20),
+                stackView.rightAnchor.constraint(equalTo: rightAnchor, constant: 20),
+                stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                stackView.topAnchor.constraint(equalTo: topAnchor),
+                stackView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5),
+                stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+                stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            ])
+        }
 
         stackView.addArrangedSubview(label)
         NSLayoutConstraint.activate([
@@ -103,12 +114,23 @@ final class ZLAdjustHSlider: UIView {
             slider.rightAnchor.constraint(equalTo: stackView.rightAnchor),
         ])
     }
+}
 
-    // MARK: View Lifecycle
+@available(iOS 14.0, *)
+extension ZLAdjustHSlider {
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        stackView.frame = .init(x: 0, y: 0, width: frame.width, height: frame.height)
+    @objc func onSliderTapped(_ recognizer: UITapGestureRecognizer) {
+        let tapLocation = recognizer.location(in: slider)
+        let sliderHalfWidth = slider.frame.size.width / 2
+        let diff = tapLocation.x - sliderHalfWidth
+        let newValue = diff / sliderHalfWidth
+        slider.setValue(Float(newValue), animated: true)
+        updateLabel()
+        valueChanged?(slider.value)
+    }
+
+    private func updateLabel() {
+        label.text = "\(Int(slider.value * 100))"
     }
 }
 
@@ -121,7 +143,7 @@ extension ZLAdjustHSlider: ZLAdjustHSliderable {
         }
         set {
             slider.setValue(newValue, animated: false)
-            label.text = "\(Int(newValue * 100))"
+            updateLabel()
         }
     }
 }

--- a/Sources/General/ZLAdjustVSlider.swift
+++ b/Sources/General/ZLAdjustVSlider.swift
@@ -1,5 +1,5 @@
 //
-//  ZLAdjustSlider.swift
+//  ZLAdjustVSlider.swift
 //  ZLImageEditor
 //
 //  Created by long on 2021/12/17.
@@ -24,7 +24,7 @@
 
 import UIKit
 
-class ZLAdjustSlider: UIView {
+class ZLAdjustVSlider: UIView, ZLAdjustSliderable {
     static let maximumValue: Float = 1
     
     static let minimumValue: Float = -1
@@ -43,26 +43,30 @@ class ZLAdjustSlider: UIView {
     
     lazy var pan = UIPanGestureRecognizer(target: self, action: #selector(panAction(_:)))
     
+    private var valueForPanBegan: Float = 0
+    
+    var beginAdjust: (() -> Void)?
+
+    var endAdjust: (() -> Void)?
+
+    // MARK: ZLAdjustSliderable
+
+    let type: ZLAdjustSliderType = .vertical
+
     var value: Float = 0 {
         didSet {
             valueLabel.text = String(Int(roundf(value * 100)))
             tintView.frame = calculateTintFrame()
         }
     }
-    
-    private var valueForPanBegan: Float = 0
-    
-    var beginAdjust: (() -> Void)?
-    
-    var valueChanged: ((Float) -> Void)?
-    
-    var endAdjust: (() -> Void)?
-    
+
+    var valueChanged: ((Float) -> Void)? = nil
+
     deinit {
         zl_debugPrint("ZLAdjustSlider deinit")
     }
     
-    override init(frame: CGRect) {
+    override init(frame: CGRect = .zero) {
         super.init(frame: frame)
         setupUI()
         
@@ -118,7 +122,7 @@ class ZLAdjustSlider: UIView {
     
     private func calculateTintFrame() -> CGRect {
         let totalH = bounds.height / 2
-        let tintH = totalH * abs(CGFloat(value)) / CGFloat(ZLAdjustSlider.maximumValue)
+        let tintH = totalH * abs(CGFloat(value)) / CGFloat(ZLAdjustVSlider.maximumValue)
         if value > 0 {
             return CGRect(x: 0, y: totalH - tintH, width: sliderWidth, height: tintH)
         } else {
@@ -135,7 +139,7 @@ class ZLAdjustSlider: UIView {
         } else if pan.state == .changed {
             let y = -translation.y / 100
             var temp = valueForPanBegan + Float(y)
-            temp = max(ZLAdjustSlider.minimumValue, min(ZLAdjustSlider.maximumValue, temp))
+            temp = max(ZLAdjustVSlider.minimumValue, min(ZLAdjustVSlider.maximumValue, temp))
             
             if (-0.0049..<0.005) ~= temp {
                 temp = 0

--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -899,14 +899,16 @@ open class ZLEditImageViewController: UIViewController {
     
     func changeAdjustTool(_ tool: ZLImageEditorConfiguration.AdjustTool) {
         selectedAdjustTool = tool
-        let value: Float = {
-            switch tool {
-            case .brightness: return brightness
-            case .contrast: return contrast
-            case .saturation: return saturation
-            }
-        }()
-        adjustSlider?.value = value
+
+        switch tool {
+        case .brightness:
+            adjustSlider?.value = brightness
+        case .contrast:
+            adjustSlider?.value = contrast
+        case .saturation:
+            adjustSlider?.value = saturation
+        }
+
         generateAdjustImageRef()
     }
     

--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -462,9 +462,11 @@ open class ZLEditImageViewController: UIViewController {
                                             height: 200)
             case .horizontal:
                 let sliderHeight = 60.0
-                adjustSlider.frame = .init(x: 0,
+                let sliderWidth = UIDevice.current.userInterfaceIdiom == .phone ? view.zl.width : view.zl.width / 2
+                let x = (view.zl.width - sliderWidth) / 2
+                adjustSlider.frame = .init(x: x,
                                            y: bottomShadowView.zl.top - sliderHeight,
-                                           width: view.zl.width,
+                                           width: sliderWidth,
                                            height: sliderHeight)
             }
         }

--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -89,8 +89,6 @@ open class ZLEditImageViewController: UIViewController {
     public var filterColViewH: CGFloat = 80
     
     public var adjustColViewH: CGFloat = 60
-
-    public var adjustHSliderH: CGFloat = 60
     
     public var ashbinSize = CGSize(width: 160, height: 80)
     
@@ -204,18 +202,20 @@ open class ZLEditImageViewController: UIViewController {
     
     open lazy var ashbinImgView = UIImageView(image: getImage("zl_ashbin"), highlightedImage: getImage("zl_ashbin_open"))
     
-    lazy var adjustSlider: ZLAdjustSlider? = {
-        if ZLImageEditorUIConfiguration.default().adjustSliderType == .horizontal { return nil }
-        return ZLAdjustSlider()
-    }()
-
-    lazy var adjustHSlider: ZLAdjustHSliderable? = {
-        guard ZLImageEditorUIConfiguration.default().adjustSliderType == .horizontal else { return nil }
-        let adjustHSlider = ZLAdjustHSlider(frame: .zero)
-        adjustHSlider.valueChanged = { [weak self] value in
+    lazy var adjustSlider: ZLAdjustSliderable? = {
+        guard ZLImageEditorConfiguration.default().tools.contains(.adjust) else { return nil }
+        let slider: ZLAdjustSliderable
+        switch ZLImageEditorUIConfiguration.default().adjustSliderType {
+        case .vertical:
+            slider = ZLAdjustVSlider()
+        case .horizontal:
+            slider = ZLAdjustHSlider()
+        }
+        slider.valueChanged = { [weak self] value in
             self?.adjustValueChanged(value)
         }
-        return adjustHSlider
+        slider.isHidden = true
+        return slider
     }()
     
     var animateDismiss = true
@@ -453,12 +453,21 @@ open class ZLEditImageViewController: UIViewController {
         drawColorCollectionView?.frame = CGRect(x: 20, y: 20, width: revokeBtn.zl.left - 20 - 10, height: drawColViewH)
         
         adjustCollectionView?.frame = CGRect(x: 20, y: 10, width: view.zl.width - 40, height: adjustColViewH)
-        adjustSlider?.frame = CGRect(x: view.zl.width - 60, y: view.zl.height / 2 - 100, width: 60, height: 200)
-        
-        adjustHSlider?.frame = .init(x: 0,
-                                     y: bottomShadowView.zl.top - adjustHSliderH,
-                                     width: view.zl.width,
-                                     height: adjustHSliderH)
+        if let adjustSlider = adjustSlider {
+            switch adjustSlider.type {
+            case .vertical:
+                adjustSlider.frame = CGRect(x: view.zl.width - 60,
+                                            y: view.zl.height / 2 - 100,
+                                            width: 60,
+                                            height: 200)
+            case .horizontal:
+                let sliderHeight = 60.0
+                adjustSlider.frame = .init(x: 0,
+                                           y: bottomShadowView.zl.top - sliderHeight,
+                                           width: view.zl.width,
+                                           height: sliderHeight)
+            }
+        }
 
         filterCollectionView?.frame = CGRect(x: 20, y: 0, width: view.zl.width - 40, height: filterColViewH)
         
@@ -658,17 +667,9 @@ open class ZLEditImageViewController: UIViewController {
             if let selectedAdjustTool = selectedAdjustTool {
                 changeAdjustTool(selectedAdjustTool)
             }
-            adjustSlider?.beginAdjust = {}
-            adjustSlider?.valueChanged = { [weak self] value in
-                self?.adjustValueChanged(value)
-            }
-            adjustSlider?.isHidden = true
+
             if let adjustSlider = adjustSlider {
                 view.addSubview(adjustSlider)
-            }
-
-            if let adjustHSlider = adjustHSlider {
-                view.addSubview(adjustHSlider)
             }
         }
         
@@ -786,7 +787,6 @@ open class ZLEditImageViewController: UIViewController {
         filterCollectionView?.isHidden = true
         adjustCollectionView?.isHidden = true
         adjustSlider?.isHidden = true
-        adjustHSlider?.isHidden = true
     }
     
     func clipBtnClick() {
@@ -824,7 +824,6 @@ open class ZLEditImageViewController: UIViewController {
             self.topShadowView.alpha = 0
             self.bottomShadowView.alpha = 0
             self.adjustSlider?.alpha = 0
-            self.adjustHSlider?.alpha = 0
         }
     }
     
@@ -860,7 +859,6 @@ open class ZLEditImageViewController: UIViewController {
         filterCollectionView?.isHidden = true
         adjustCollectionView?.isHidden = true
         adjustSlider?.isHidden = true
-        adjustHSlider?.isHidden = true
         revokeBtn.isHidden = !isSelected
         revokeBtn.isEnabled = !mosaicPaths.isEmpty
         redoBtn?.isHidden = !isSelected
@@ -880,7 +878,6 @@ open class ZLEditImageViewController: UIViewController {
         filterCollectionView?.isHidden = !isSelected
         adjustCollectionView?.isHidden = true
         adjustSlider?.isHidden = true
-        adjustHSlider?.isHidden = true
     }
     
     func adjustBtnClick() {
@@ -896,7 +893,6 @@ open class ZLEditImageViewController: UIViewController {
         filterCollectionView?.isHidden = true
         adjustCollectionView?.isHidden = !isSelected
         adjustSlider?.isHidden = !isSelected
-        adjustHSlider?.isHidden = !isSelected
         
         generateAdjustImageRef()
     }
@@ -911,7 +907,6 @@ open class ZLEditImageViewController: UIViewController {
             }
         }()
         adjustSlider?.value = value
-        adjustHSlider?.value = value
         generateAdjustImageRef()
     }
     
@@ -1159,14 +1154,12 @@ open class ZLEditImageViewController: UIViewController {
                 self.topShadowView.alpha = 1
                 self.bottomShadowView.alpha = 1
                 self.adjustSlider?.alpha = 1
-                self.adjustHSlider?.alpha = 1
             }
         } else {
             UIView.animate(withDuration: 0.25) {
                 self.topShadowView.alpha = 0
                 self.bottomShadowView.alpha = 0
                 self.adjustSlider?.alpha = 0
-                self.adjustHSlider?.alpha = 0
             }
         }
     }
@@ -1418,7 +1411,6 @@ open class ZLEditImageViewController: UIViewController {
             self.topShadowView.alpha = 1
             self.bottomShadowView.alpha = 1
             self.adjustSlider?.alpha = 1
-            self.adjustHSlider?.alpha = 1
         }
     }
 }

--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -205,14 +205,12 @@ open class ZLEditImageViewController: UIViewController {
     open lazy var ashbinImgView = UIImageView(image: getImage("zl_ashbin"), highlightedImage: getImage("zl_ashbin_open"))
     
     lazy var adjustSlider: ZLAdjustSlider? = {
-        if #available(iOS 14.0, *),
-              ZLImageEditorUIConfiguration.default().adjustSliderType == .horizontal { return nil }
+        if ZLImageEditorUIConfiguration.default().adjustSliderType == .horizontal { return nil }
         return ZLAdjustSlider()
     }()
 
     lazy var adjustHSlider: ZLAdjustHSliderable? = {
-        guard #available(iOS 14.0, *),
-              ZLImageEditorUIConfiguration.default().adjustSliderType == .horizontal else { return nil }
+        guard ZLImageEditorUIConfiguration.default().adjustSliderType == .horizontal else { return nil }
         let adjustHSlider = ZLAdjustHSlider(frame: .zero)
         adjustHSlider.valueChanged = { [weak self] value in
             self?.adjustValueChanged(value)

--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -664,9 +664,6 @@ open class ZLEditImageViewController: UIViewController {
             adjustSlider?.valueChanged = { [weak self] value in
                 self?.adjustValueChanged(value)
             }
-            adjustSlider?.endAdjust = { [weak self] in
-                self?.endAdjust()
-            }
             adjustSlider?.isHidden = true
             if let adjustSlider = adjustSlider {
                 view.addSubview(adjustSlider)
@@ -858,7 +855,9 @@ open class ZLEditImageViewController: UIViewController {
         } else {
             selectedTool = nil
         }
-        
+
+        endAdjust()
+
         drawColorCollectionView?.isHidden = true
         filterCollectionView?.isHidden = true
         adjustCollectionView?.isHidden = true

--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -457,9 +457,9 @@ open class ZLEditImageViewController: UIViewController {
         adjustCollectionView?.frame = CGRect(x: 20, y: 10, width: view.zl.width - 40, height: adjustColViewH)
         adjustSlider?.frame = CGRect(x: view.zl.width - 60, y: view.zl.height / 2 - 100, width: 60, height: 200)
         
-        adjustHSlider?.frame = .init(x: 20,
+        adjustHSlider?.frame = .init(x: 0,
                                      y: bottomShadowView.zl.top - adjustHSliderH,
-                                     width: view.zl.width - 40,
+                                     width: view.zl.width,
                                      height: adjustHSliderH)
 
         filterCollectionView?.frame = CGRect(x: 20, y: 0, width: view.zl.width - 40, height: filterColViewH)

--- a/Sources/General/ZLImageEditorDefine.swift
+++ b/Sources/General/ZLImageEditorDefine.swift
@@ -61,3 +61,9 @@ func deviceSafeAreaInsets() -> UIEdgeInsets {
 func zl_debugPrint(_ message: Any) {
 //    debugPrint(message)
 }
+
+protocol ZLAdjustSliderable: UIView {
+    var type: ZLAdjustSliderType { get }
+    var value: Float { get set }
+    var valueChanged: ((Float) -> Void)? { get set }
+}

--- a/Sources/General/ZLImageEditorUIConfiguration+Chaining.swift
+++ b/Sources/General/ZLImageEditorUIConfiguration+Chaining.swift
@@ -34,7 +34,6 @@ public extension ZLImageEditorUIConfiguration {
     }
 
     @discardableResult
-    @available(iOS 14.0, *)
     func adjustSliderType(_ type: ZLAdjustSliderType) -> ZLImageEditorUIConfiguration {
         adjustSliderType = type
         return self

--- a/Sources/General/ZLImageEditorUIConfiguration+Chaining.swift
+++ b/Sources/General/ZLImageEditorUIConfiguration+Chaining.swift
@@ -32,6 +32,13 @@ public extension ZLImageEditorUIConfiguration {
         hudStyle = style
         return self
     }
+
+    @discardableResult
+    @available(iOS 14.0, *)
+    func adjustSliderType(_ type: ZLAdjustSliderType) -> ZLImageEditorUIConfiguration {
+        adjustSliderType = type
+        return self
+    }
     
     @discardableResult
     func languageType(_ type: ZLImageEditorLanguageType) -> ZLImageEditorUIConfiguration {

--- a/Sources/General/ZLImageEditorUIConfiguration.swift
+++ b/Sources/General/ZLImageEditorUIConfiguration.swift
@@ -41,7 +41,6 @@ public class ZLImageEditorUIConfiguration: NSObject {
     @objc public var hudStyle: ZLProgressHUD.HUDStyle = .dark
 
     /// Adjust Slider Type
-    @available(iOS 14.0, *)
     public lazy var adjustSliderType: ZLAdjustSliderType = .vertical
     
     // MARK: Language properties
@@ -142,7 +141,6 @@ enum ZLCustomImageDeploy {
 
 // MARK: Ajust Slider
 
-@available(iOS 14.0, *)
 public enum ZLAdjustSliderType {
     case vertical, horizontal
 }

--- a/Sources/General/ZLImageEditorUIConfiguration.swift
+++ b/Sources/General/ZLImageEditorUIConfiguration.swift
@@ -39,6 +39,10 @@ public class ZLImageEditorUIConfiguration: NSObject {
     
     /// HUD style. Defaults to dark.
     @objc public var hudStyle: ZLProgressHUD.HUDStyle = .dark
+
+    /// Adjust Slider Type
+    @available(iOS 14.0, *)
+    public lazy var adjustSliderType: ZLAdjustSliderType = .vertical
     
     // MARK: Language properties
     
@@ -134,4 +138,11 @@ enum ZLCustomImageDeploy {
     static var imageNames: [String] = []
     
     static var imageForKey: [String: UIImage] = [:]
+}
+
+// MARK: Ajust Slider
+
+@available(iOS 14.0, *)
+public enum ZLAdjustSliderType {
+    case vertical, horizontal
 }

--- a/ZLImageEditor.xcodeproj/project.pbxproj
+++ b/ZLImageEditor.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		E4020912256BA27D0077F5DC /* ZLImageEditorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4020911256BA27D0077F5DC /* ZLImageEditorConfiguration.swift */; };
 		FD1551CA28BE2C720043D844 /* UIView+ZLImageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1551C928BE2C720043D844 /* UIView+ZLImageEditor.swift */; };
 		FD7E7508284E134600EF34DD /* ZLProgressHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7E7507284E134600EF34DD /* ZLProgressHUD.swift */; };
-		FD8EFA522772026D0067ADF1 /* ZLAdjustSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8EFA512772026D0067ADF1 /* ZLAdjustSlider.swift */; };
+		FD8EFA522772026D0067ADF1 /* ZLAdjustVSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8EFA512772026D0067ADF1 /* ZLAdjustVSlider.swift */; };
 		FD8EFA54277206D30067ADF1 /* ZLEditToolCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8EFA53277206D30067ADF1 /* ZLEditToolCells.swift */; };
 		FD8EFA562772CF3B0067ADF1 /* ZLImageEditorConfiguration+Chaining.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8EFA552772CF3B0067ADF1 /* ZLImageEditorConfiguration+Chaining.swift */; };
 		FDB3113328752F7300845756 /* ZLWeakProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3113228752F7300845756 /* ZLWeakProxy.swift */; };
@@ -61,7 +61,7 @@
 		E4020911256BA27D0077F5DC /* ZLImageEditorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZLImageEditorConfiguration.swift; sourceTree = "<group>"; };
 		FD1551C928BE2C720043D844 /* UIView+ZLImageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ZLImageEditor.swift"; sourceTree = "<group>"; };
 		FD7E7507284E134600EF34DD /* ZLProgressHUD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZLProgressHUD.swift; sourceTree = "<group>"; };
-		FD8EFA512772026D0067ADF1 /* ZLAdjustSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZLAdjustSlider.swift; sourceTree = "<group>"; };
+		FD8EFA512772026D0067ADF1 /* ZLAdjustVSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZLAdjustVSlider.swift; sourceTree = "<group>"; };
 		FD8EFA53277206D30067ADF1 /* ZLEditToolCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZLEditToolCells.swift; sourceTree = "<group>"; };
 		FD8EFA552772CF3B0067ADF1 /* ZLImageEditorConfiguration+Chaining.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZLImageEditorConfiguration+Chaining.swift"; sourceTree = "<group>"; };
 		FDB3113228752F7300845756 /* ZLWeakProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZLWeakProxy.swift; sourceTree = "<group>"; };
@@ -126,7 +126,7 @@
 				E40208E5256B9F9C0077F5DC /* ZLImageStickerView.swift */,
 				E40208E6256B9F9C0077F5DC /* ZLTextStickerView.swift */,
 				FD8EFA53277206D30067ADF1 /* ZLEditToolCells.swift */,
-				FD8EFA512772026D0067ADF1 /* ZLAdjustSlider.swift */,
+				FD8EFA512772026D0067ADF1 /* ZLAdjustVSlider.swift */,
 				5F7AC606293DE16400BC67BC /* ZLAdjustHSlider.swift */,
 				E40208EA256B9F9C0077F5DC /* ZLFilter.swift */,
 				E40208F3256B9FA70077F5DC /* ZLClipImageDismissAnimatedTransition.swift */,
@@ -250,7 +250,7 @@
 				E40208F7256B9FCB0077F5DC /* CGFloat+ZLImageEditor.swift in Sources */,
 				FDE1A55D282E595C00178B0F /* UIColor+ZLImageEditor.swift in Sources */,
 				FD8EFA562772CF3B0067ADF1 /* ZLImageEditorConfiguration+Chaining.swift in Sources */,
-				FD8EFA522772026D0067ADF1 /* ZLAdjustSlider.swift in Sources */,
+				FD8EFA522772026D0067ADF1 /* ZLAdjustVSlider.swift in Sources */,
 				E40208EB256B9F9C0077F5DC /* ZLEditImageViewController.swift in Sources */,
 				E402090E256BA1F40077F5DC /* ZLImageEditorLanguageDefine.swift in Sources */,
 				E40208EF256B9F9C0077F5DC /* ZLInputTextViewController.swift in Sources */,

--- a/ZLImageEditor.xcodeproj/project.pbxproj
+++ b/ZLImageEditor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5F7AC607293DE16400BC67BC /* ZLAdjustHSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7AC606293DE16400BC67BC /* ZLAdjustHSlider.swift */; };
 		E40208DC256B9BA60077F5DC /* ZLImageEditor.h in Headers */ = {isa = PBXBuildFile; fileRef = E40208DA256B9BA60077F5DC /* ZLImageEditor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E40208EB256B9F9C0077F5DC /* ZLEditImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40208E4256B9F9C0077F5DC /* ZLEditImageViewController.swift */; };
 		E40208EC256B9F9C0077F5DC /* ZLImageStickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40208E5256B9F9C0077F5DC /* ZLImageStickerView.swift */; };
@@ -38,6 +39,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5F7AC606293DE16400BC67BC /* ZLAdjustHSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZLAdjustHSlider.swift; sourceTree = "<group>"; };
 		E40208D7256B9BA60077F5DC /* ZLImageEditor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZLImageEditor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E40208DA256B9BA60077F5DC /* ZLImageEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZLImageEditor.h; sourceTree = "<group>"; };
 		E40208DB256B9BA60077F5DC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				E40208E6256B9F9C0077F5DC /* ZLTextStickerView.swift */,
 				FD8EFA53277206D30067ADF1 /* ZLEditToolCells.swift */,
 				FD8EFA512772026D0067ADF1 /* ZLAdjustSlider.swift */,
+				5F7AC606293DE16400BC67BC /* ZLAdjustHSlider.swift */,
 				E40208EA256B9F9C0077F5DC /* ZLFilter.swift */,
 				E40208F3256B9FA70077F5DC /* ZLClipImageDismissAnimatedTransition.swift */,
 				FDD5289126C3FFCA00338B06 /* ZLImageEditor.swift */,
@@ -253,6 +256,7 @@
 				E40208EF256B9F9C0077F5DC /* ZLInputTextViewController.swift in Sources */,
 				E40208F1256B9F9C0077F5DC /* ZLFilter.swift in Sources */,
 				FDB3113328752F7300845756 /* ZLWeakProxy.swift in Sources */,
+				5F7AC607293DE16400BC67BC /* ZLAdjustHSlider.swift in Sources */,
 				E402090A256BA1DE0077F5DC /* ZLImageEditorDefine.swift in Sources */,
 				E40208ED256B9F9C0077F5DC /* ZLTextStickerView.swift in Sources */,
 			);


### PR DESCRIPTION
Hi @longitachi,

I'd like to propose a proposal.
I got feedback from a user of my app that the vertical slider is difficult to use. 
The user is using a smartphone case, and the edges of the screen are covered by the case, making it difficult to press the slider.

So, I added the horizontal adjust slider and the configuration to allow switching between each.
I'd be happy if you'd review this proposal.

Thank you.

```swift
ZLImageEditorUIConfiguration.default()
    .adjustSliderType(.horizontal)
```

iPhone | iPad
--- | ---
<img width="450" alt="Screen Shot 2022-12-06 at 12 02 04" src="https://user-images.githubusercontent.com/19259885/206836320-62c7cdd9-89f3-4070-b37f-9d990fd3084f.png"> |<img width="450" alt="Screen Shot 2022-12-06 at 12 01 57" src="https://user-images.githubusercontent.com/19259885/206836321-71237b6a-0ec6-4403-bb27-1ca412e41b5b.png">

<img width="450" src="https://user-images.githubusercontent.com/19259885/206836471-20833447-de9d-4015-8f6c-1e0a37af606d.gif">

