### PR TITLE
hide redo button when filtering or color adjusting

### DIFF
--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -851,6 +851,7 @@ open class ZLEditImageViewController: UIViewController {
         
         drawColorCollectionView?.isHidden = true
         revokeBtn.isHidden = true
+        redoBtn?.isHidden = true
         filterCollectionView?.isHidden = !isSelected
         adjustCollectionView?.isHidden = true
         adjustSlider?.isHidden = true
@@ -866,6 +867,7 @@ open class ZLEditImageViewController: UIViewController {
         
         drawColorCollectionView?.isHidden = true
         revokeBtn.isHidden = true
+        redoBtn?.isHidden = true
         filterCollectionView?.isHidden = true
         adjustCollectionView?.isHidden = !isSelected
         adjustSlider?.isHidden = !isSelected


### PR DESCRIPTION
Hi @longitachi,

I fixed a bug which the redo button remained displayed when in filtering mode and color adjustment mode.

Before | After
--- | ---
<img width="200" alt="Screen Shot 2022-12-07 at 10 24 09" src="https://user-images.githubusercontent.com/19259885/206064797-58cd0cbb-8b90-4dce-b371-1ec305d15c04.png"> | <img width="200" alt="Screen Shot 2022-12-07 at 10 24 58" src="https://user-images.githubusercontent.com/19259885/206064905-ed800a40-4cea-4a30-a53d-8862ad043324.png">
<img width="200" alt="Screen Shot 2022-12-07 at 10 24 24" src="https://user-images.githubusercontent.com/19259885/206064831-c29eda5d-1c72-46e8-9613-39cfb0a3998f.png"> | <img width="200" alt="Screen Shot 2022-12-07 at 10 25 11" src="https://user-images.githubusercontent.com/19259885/206064920-62fa8501-ba4f-487f-bcac-dd0ba36d53f5.png">