### PR TITLE
Update Korean Localizable.strings

### DIFF
--- a/Sources/ZLImageEditor.bundle/ko.lproj/Localizable.strings
+++ b/Sources/ZLImageEditor.bundle/ko.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 "cancel" = "취소";
-"done" = "끝난";
+"done" = "완료";
 "editFinish" = "완료";
 "revert" = "실행 취소";
 "brightness" = "밝기";


### PR DESCRIPTION
Hi @longitachi,

I updated Korean localization.
I'm appreciate if you would review this proposal.

![스크린샷 2023-03-23 오후 12 43 59](https://user-images.githubusercontent.com/22820675/227097487-5c799d91-16af-4e71-be04-038bb4a77870.png)

Nobody in Korean uses "끝난" for done. And KakaoTalk translation is totally off anyway. 
As a native speaker, I can tell you that "완료" is the correct term here.