### PR TITLE
Change `returnKeyType` when line breaks are enabled in `TextSticker`

### DIFF
--- a/Sources/General/ZLInputTextViewController.swift
+++ b/Sources/General/ZLInputTextViewController.swift
@@ -248,7 +248,8 @@ class ZLInputTextViewController: UIViewController {
         toolView.addSubview(collectionView)
         
         textView.textAlignment = .left
-        
+        textView.returnKeyType = ZLImageEditorConfiguration.default().textStickerCanLineBreak ? .default : .done
+
         refreshTextViewUI()
     }
     


### PR DESCRIPTION
# Summary
Hello!
Thank you for providing such a great library.

I'd like to suggest a small improvement to the TextSticker feature.

Currently, when `textStickerCanLineBreak` is enabled in `ZLImageEditorConfiguration`, the return key on the keyboard remains set to `.done`. This can make it unclear to users that line breaks are supported.

**Before**
| Line break enabled | Line Break Disabled |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/b2ebaab7-05cd-44ba-931f-d96ca90bfa3d" width=300 /> | <img src="https://github.com/user-attachments/assets/8a8ea0e8-7328-4d0b-9ce2-6ea57c284604" width=300 /> |


To improve the user experience, I’ve updated the return key to `.default` when `textStickerCanLineBreak` is enabled. This change makes the keyboard UI better reflect the ability to insert line breaks.

**After**
| Line break enabled | Line Break Disabled |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/017bc2f2-a643-4f4b-8120-2baca7ddc69c" width=300 /> | <img src="https://github.com/user-attachments/assets/837d5b69-de29-4031-81c7-beab39728ffc" width=300 /> |

Thank you!