### PR TITLE
fix dismiss animation after clip view when presenting from SwiftUI

### DIFF
--- a/Sources/General/ZLClipImageDismissAnimatedTransition.swift
+++ b/Sources/General/ZLClipImageDismissAnimatedTransition.swift
@@ -27,12 +27,21 @@
 import UIKit
 
 class ZLClipImageDismissAnimatedTransition: NSObject, UIViewControllerAnimatedTransitioning {
+    var presentingEditViewController: ZLEditImageViewController?
+    
+    init(presentingEditViewController: ZLEditImageViewController?) {
+        self.presentingEditViewController = presentingEditViewController
+    }
+    
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return 0.25
     }
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        guard let fromVC = transitionContext.viewController(forKey: .from) as? ZLClipImageViewController, let toVC = transitionContext.viewController(forKey: .to) as? ZLEditImageViewController else {
+        guard
+            let fromVC = transitionContext.viewController(forKey: .from) as? ZLClipImageViewController,
+            let toVC = transitionContext.viewController(forKey: .to),
+            let presentingEditViewController else {
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
             return
         }
@@ -47,9 +56,9 @@ class ZLClipImageDismissAnimatedTransition: NSObject, UIViewControllerAnimatedTr
         containerView.addSubview(imageView)
         
         UIView.animate(withDuration: 0.3, animations: {
-            imageView.frame = toVC.originalFrame
+            imageView.frame = presentingEditViewController.originalFrame
         }) { _ in
-            toVC.finishClipDismissAnimate()
+            presentingEditViewController.finishClipDismissAnimate()
             imageView.removeFromSuperview()
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }

--- a/Sources/General/ZLClipImageViewController.swift
+++ b/Sources/General/ZLClipImageViewController.swift
@@ -58,6 +58,8 @@ class ZLClipImageViewController: UIViewController {
     
     var editRect: CGRect
     
+    var presentingEditViewController: ZLEditImageViewController?
+    
     /// 初次进去界面时的动画占位view
     private lazy var animateImageView: UIImageView? = {
         guard let presentAnimateFrame, let presentAnimateImage else {
@@ -284,7 +286,7 @@ class ZLClipImageViewController: UIViewController {
         super.viewDidAppear(animated)
         
         viewDidAppearCount += 1
-        if presentingViewController is ZLEditImageViewController {
+        if presentingEditViewController != nil {
             transitioningDelegate = self
         }
         
@@ -1070,7 +1072,7 @@ extension ZLClipImageViewController: UIScrollViewDelegate {
 
 extension ZLClipImageViewController: UIViewControllerTransitioningDelegate {
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return ZLClipImageDismissAnimatedTransition()
+        return ZLClipImageDismissAnimatedTransition(presentingEditViewController: presentingEditViewController)
     }
 }
 

--- a/Sources/General/ZLEditImageViewController.swift
+++ b/Sources/General/ZLEditImageViewController.swift
@@ -933,6 +933,7 @@ open class ZLEditImageViewController: UIViewController {
         
         let vc = ZLClipImageViewController(image: currentEditImage, status: currentClipStatus)
         let rect = mainScrollView.convert(containerView.frame, to: view)
+        vc.presentingEditViewController = self
         vc.presentAnimateFrame = rect
         vc.presentAnimateImage = currentEditImage.zl
             .clipImage(


### PR DESCRIPTION
Fix edit view being completely black after dismissing the clip view when presenting from SwiftUI

See https://github.com/longitachi/ZLImageEditor/issues/61